### PR TITLE
Showing select boxes on mobile

### DIFF
--- a/src/components/TableSelectCell.js
+++ b/src/components/TableSelectCell.js
@@ -7,11 +7,6 @@ import { withStyles } from '@material-ui/core/styles';
 import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight';
 
 const defaultSelectCellStyles = theme => ({
-  root: {
-    [theme.breakpoints.down('sm')]: {
-      display: 'none',
-    },
-  },
   fixedHeader: {
     position: 'sticky',
     top: '0px',


### PR DESCRIPTION
The select box was hidden after the `sm` breakpoint but we need users to be able to add items to the table on mobile so I've removed the display none.

The table natural scrolls right when the items don't fit on the screen, I think this is good enough for now and allows us to keep consistent functionality.

<img width="371" alt="Screenshot 2019-03-14 at 21 32 21" src="https://user-images.githubusercontent.com/423637/54393006-f45da400-46a0-11e9-9500-acd30912b510.png">

